### PR TITLE
chore: add project field to eslint config

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -31,6 +31,7 @@
   "eslintConfig": {
     "extends": "ipfs",
     "parserOptions": {
+      "project": true,
       "sourceType": "module"
     }
   },

--- a/packages/interop/package.json
+++ b/packages/interop/package.json
@@ -31,6 +31,7 @@
   "eslintConfig": {
     "extends": "ipfs",
     "parserOptions": {
+      "project": true,
       "sourceType": "module"
     }
   },

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -51,6 +51,7 @@
   "eslintConfig": {
     "extends": "ipfs",
     "parserOptions": {
+      "project": true,
       "sourceType": "module"
     }
   },


### PR DESCRIPTION
To make sure vscode can lint files properly add the project field
to the config